### PR TITLE
Update Links to Website to accommodate new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The `-b` option defines Dradis' bind address and the `-p` option can be used to 
 
 ## Getting started (stable release)
 
-In http://dradisframework.org/download.html you will find the latest packages. (pending 3.0 release)
+In https://dradis.com/ce/download.html you will find the latest packages. (pending 3.0 release)
 
 
 <!-- Uncompress, verify and prepare the environment:
@@ -118,7 +118,7 @@ number, you can use the -b and -p switches respectively:
 
 ## Getting help
 
-* http://dradisframework.org/
+* https://dradis.com/ce/
 * Dradis Guides: http://guides.dradisframework.org
 * [Community Forums](http://discuss.dradisframework.org/)
 * IRC: **#dradis** `irc.freenode.org`


### PR DESCRIPTION
We migrated our website to dradis.com in 2023, but Google doesn’t seem to have figured out that dradis.com is our new domain, and we’re losing a lot of traffic as a result.

We’re trying to update links to our previous domains, so they link directly to the new domain. I'd really appreciate it if you'd be able to update this link for me.

Thank you

# This repo is abandoned!

Please open your Pull request in the current repo at:

https://github.com/dradis/dradis-ce/pulls
